### PR TITLE
🎛️ Fix: The scrollbar in the units' pane on Chrome doesn't break the grid

### DIFF
--- a/src/topic/Heraldry/components/Panes/FiltersPane.tsx
+++ b/src/topic/Heraldry/components/Panes/FiltersPane.tsx
@@ -235,7 +235,7 @@ const FiltersPane = ({
         shouldIgnoreFormer={shouldIgnoreFormer}
         setShouldIgnoreFormer={setShouldIgnoreFormer}
       />}
-      {activeMenu === 'color' && <SubPanel order={2} className="ui-slide-from-right-sidebar z-[-1] mt-2 absolute right-12 mr-2 flex-row">
+      {activeMenu === 'color' && <SubPanel order={2} className="ui-slide-from-right-sidebar no-scrollbar z-[-1] mt-2 absolute right-12 mr-2 flex-row">
         {Object.keys(colorsMarkersByNames).map((name) => <ButtonIcon
           key={name}
           wrapperClassName="relative bg-white rounded-[8px]"
@@ -267,7 +267,7 @@ const FiltersPane = ({
         toggle={toggleItem}
         filtersList={itemFiltersList}
       />}
-      {activeMenu === 'settings' && <SubPanel order={5} className="ui-slide-from-right-sidebar z-[-1] mt-2 absolute right-12 mr-2 flex-row">
+      {activeMenu === 'settings' && <SubPanel order={5} className="ui-slide-from-right-sidebar no-scrollbar z-[-1] mt-2 absolute right-12 mr-2 flex-row">
         <ButtonIcon
           wrapperClassName="ml-auto"
           onClick={() => setFilterOperator(filterOperator === 'and' ? 'or' : 'and')}

--- a/src/topic/Heraldry/components/Panes/FiltersPane/FiltersPaneSidebarAnimals.tsx
+++ b/src/topic/Heraldry/components/Panes/FiltersPane/FiltersPaneSidebarAnimals.tsx
@@ -63,7 +63,7 @@ const FiltersPaneSidebarTypes = ({
   const activeTotal = filters.length;
 
   return (
-    <div className="ui-slide-from-right-sidebar fixed top-0 right-0 z-[-1] w-[400px] max-w-[100vw] max-h-[100svh] overflow-auto">
+    <div className="ui-slide-from-right-sidebar no-scrollbar fixed top-0 right-0 z-[-1] w-[400px] max-w-[100vw] max-h-[100svh] overflow-auto">
       <div className="bg-ui-dark text-ui-dark-contrast p-[12px] pr-[60px] rounded-bl-[18px] flex flex-col gap-[12px] relative">
         <h3 className="flex gap-3 items-center text-[14px]">
           <IconAnimal className="size-5 text-white" />

--- a/src/topic/Heraldry/components/Panes/FiltersPane/FiltersPaneSidebarItems.tsx
+++ b/src/topic/Heraldry/components/Panes/FiltersPane/FiltersPaneSidebarItems.tsx
@@ -59,7 +59,7 @@ const FiltersPaneSidebarItems = ({
   const activeTotal = filters.length;
 
   return (
-    <div className="ui-slide-from-right-sidebar fixed top-0 right-0 z-[-1] w-[400px] max-w-[100vw] max-h-[100svh] overflow-auto">
+    <div className="ui-slide-from-right-sidebar no-scrollbar fixed top-0 right-0 z-[-1] w-[400px] max-w-[100vw] max-h-[100svh] overflow-auto">
       <div className="bg-ui-dark text-ui-dark-contrast p-[12px] pr-[60px] rounded-bl-[18px] flex flex-col gap-[12px] relative">
         <h3 className="flex gap-3 items-center text-[14px]">
           <IconCrown className="size-5 text-white" />

--- a/src/topic/Heraldry/components/Panes/FiltersPane/FiltersPaneSidebarTypes.tsx
+++ b/src/topic/Heraldry/components/Panes/FiltersPane/FiltersPaneSidebarTypes.tsx
@@ -73,7 +73,7 @@ const FiltersPaneSidebarTypes = ({
   const activeTotal = filters.length + (shouldIgnoreFormer ? 1 : 0);
 
   return (
-    <div className="ui-slide-from-right-sidebar fixed top-0 right-0 z-[-1] w-[400px] max-w-[100vw] max-h-[100svh] overflow-auto">
+    <div className="ui-slide-from-right-sidebar no-scrollbar fixed top-0 right-0 z-[-1] w-[400px] max-w-[100vw] max-h-[100svh] overflow-auto">
       <div className="bg-ui-dark text-ui-dark-contrast p-[12px] pr-[60px] rounded-bl-[18px] flex flex-col gap-[12px] relative">
         <h3 className="flex gap-3 items-center text-[14px]">
           <IconBuilding className="size-5 text-white" />

--- a/src/topic/Heraldry/components/Panes/UnitsPane/UnitsPaneSidebar.tsx
+++ b/src/topic/Heraldry/components/Panes/UnitsPane/UnitsPaneSidebar.tsx
@@ -66,7 +66,7 @@ const UnitsPaneSidebar = ({
   const canUseGrid = units.length > 4;
 
   return (
-    <div className="ui-slide-from-right-sidebar fixed top-0 right-0 z-[-1] w-[400px] max-w-[100vw] max-h-[100svh] overflow-auto">
+    <div className="ui-slide-from-right-sidebar no-scrollbar fixed top-0 right-0 z-[-1] w-[400px] max-w-[100vw] max-h-[100svh] overflow-auto">
       <div className="bg-ui-dark text-ui-dark-contrast p-[12px] pr-[60px] rounded-bl-[18px] flex flex-col gap-[12px] relative">
         {detailsUnit ?
           <UnitsPaneSidebarDetailsContent unit={detailsUnit} setDetailsUnit={setDetailsUnit}/>

--- a/src/topic/Heraldry/components/Panes/ZoomPane.tsx
+++ b/src/topic/Heraldry/components/Panes/ZoomPane.tsx
@@ -60,7 +60,7 @@ const ZoomPane = ({
       </Panel>
       {isOpen && <SubPanel
         order={2}
-        className="ui-slide-from-right-sidebar z-[-1] absolute top-0 right-12 mr-2 flex-row items-center"
+        className="ui-slide-from-right-sidebar no-scrollbar z-[-1] absolute top-0 right-12 mr-2 flex-row items-center"
       >
         <ButtonIcon onClick={() => setCoatSize(coatSize - 1)} isDisabled={coatSize === coatMin}>
           <IconMinus />


### PR DESCRIPTION
### Before
![obraz](https://github.com/user-attachments/assets/6d475613-68e0-4f14-8b2c-16b832e4f048)

### After
![obraz](https://github.com/user-attachments/assets/567552cf-ebfb-418f-95b7-dd049540b1db)
