### PR TITLE
📈 Performence: The Units pane search has been throttled to improve performance

### DIFF
--- a/src/topic/Heraldry/components/Panes/UnitsPane/UnitsPaneSearchInput.tsx
+++ b/src/topic/Heraldry/components/Panes/UnitsPane/UnitsPaneSearchInput.tsx
@@ -1,0 +1,59 @@
+import { memo, useState, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+
+import useEffectChange from '@/hooks/useEffectChange';
+
+
+type Props = {
+  filterPhrase: string,
+  setFilterPhrase: (value: string) => void,
+};
+
+const UnitsPaneSearchInput = ({
+  filterPhrase,
+  setFilterPhrase,
+}: Props) => {
+  const updateFilterTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [inputValue, setInputValue] = useState(filterPhrase);
+
+  const { t } = useTranslation();
+
+  useEffectChange(() => {
+    if (updateFilterTimeoutRef.current) {
+      clearTimeout(updateFilterTimeoutRef.current);
+      updateFilterTimeoutRef.current = null;
+    }
+
+    if (filterPhrase !== inputValue) {
+      updateFilterTimeoutRef.current = setTimeout(() => {
+        setFilterPhrase(inputValue);
+
+        if (updateFilterTimeoutRef.current) {
+          clearTimeout(updateFilterTimeoutRef.current);
+          updateFilterTimeoutRef.current = null;
+        }
+      }, 500);
+    }
+  }, [inputValue]);
+
+  useEffectChange(() => {
+    if (updateFilterTimeoutRef.current) {
+      clearTimeout(updateFilterTimeoutRef.current);
+      updateFilterTimeoutRef.current = null;
+    }
+
+    setInputValue(filterPhrase);
+  }, [filterPhrase])
+
+  return (
+    <input
+      value={inputValue}
+      onChange={(e) => setInputValue(e.target.value || '')}
+      className={clsx('block w-full bg-ui-contrast text-ui-dark placeholder-ui-dark caret-marker rounded-full py-2 px-4')}
+      placeholder={t('heraldry.list.limitListToPlaceholder')}
+  />
+  );
+}
+
+export default memo(UnitsPaneSearchInput);

--- a/src/topic/Heraldry/components/Panes/UnitsPane/UnitsPaneSidebar.tsx
+++ b/src/topic/Heraldry/components/Panes/UnitsPane/UnitsPaneSidebar.tsx
@@ -18,6 +18,7 @@ import ButtonIcon from '@/components/UI/ButtonIcon';
 import UnitsPaneItemGrid from './UnitsPaneItemGrid';
 import UnitsPaneItemList from './UnitsPaneItemList';
 import UnitsPaneSidebarDetailsContent from './UnitsPaneSidebarDetailsContent';
+import UnitsPaneSearchInput from './UnitsPaneSearchInput';
 
 type Props = {
   filterPhrase: string,
@@ -76,11 +77,9 @@ const UnitsPaneSidebar = ({
               <span>{t('heraldry.list.title')}</span>
             </h3>
             <Panel className="ui-panel--rounded-l ui-panel--rounded-r">
-              <input
-                value={filterPhrase}
-                onChange={(e) => setFilterPhrase(e.target.value || '')}
-                className={clsx('block w-full bg-ui-contrast text-ui-dark placeholder-ui-dark caret-marker rounded-full py-2 px-4')}
-                placeholder={t('heraldry.list.limitListToPlaceholder')}
+              <UnitsPaneSearchInput
+                filterPhrase={filterPhrase}
+                setFilterPhrase={setFilterPhrase}
               />
               <div className="mt-2 flex gap-1">
                 <ButtonIcon


### PR DESCRIPTION
As a result, there is a delay, and typing "Berlin" doesn't trigger filtering for "Berli", "Berl", "Ber" etc.